### PR TITLE
[DO NOT MERGE] Update to swift-homomorphic-encryption release/1.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3edb4d7a61284ef997420b195205a783796b8a5f2cb7226aa59ce38398863262",
+  "originHash" : "e6ff9b48261ffa02cfad9591c9bb7e6335c34f3284b77c24bc277a425b8fe4f4",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -142,7 +142,7 @@
       "location" : "https://github.com/apple/swift-homomorphic-encryption",
       "state" : {
         "branch" : "release/1.1",
-        "revision" : "992cbe5a62938ca171e2e93a996c1e0d37f89a39"
+        "revision" : "d768d0d321d4223ba18f76ed9cc81c2b128d40e7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
                 .product(name: "HomomorphicEncryptionProtobuf", package: "swift-homomorphic-encryption"),
                 .product(name: "Hummingbird", package: "hummingbird"),
                 .product(name: "HummingbirdCompression", package: "hummingbird-compression"),
-                .product(name: "PrivateInformationRetrievalProtobuf", package: "swift-homomorphic-encryption"),
+                .product(name: "ApplicationProtobuf", package: "swift-homomorphic-encryption"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
                 .product(name: "UnixSignals", package: "swift-service-lifecycle"),
             ],
@@ -68,7 +68,7 @@ let package = Package(
             name: "ConstructDatabase",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "PrivateInformationRetrievalProtobuf", package: "swift-homomorphic-encryption"),
+                .product(name: "ApplicationProtobuf", package: "swift-homomorphic-encryption"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
             ],
             exclude: ["protobuf"],
@@ -101,7 +101,7 @@ let package = Package(
                 "PrivacyPass", "Util",
                 .product(name: "HomomorphicEncryptionProtobuf", package: "swift-homomorphic-encryption"),
                 .product(name: "HummingbirdTesting", package: "hummingbird"),
-                .product(name: "PrivateInformationRetrievalProtobuf", package: "swift-homomorphic-encryption"),
+                .product(name: "ApplicationProtobuf", package: "swift-homomorphic-encryption"),
             ],
             swiftSettings: swiftSettings),
         .testTarget(

--- a/Sources/ConstructDatabase/ConstructDatabase.swift
+++ b/Sources/ConstructDatabase/ConstructDatabase.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ApplicationProtobuf
 import ArgumentParser
 import Foundation
-import PrivateInformationRetrievalProtobuf
 import SwiftProtobuf
 
 let discussion =

--- a/Sources/PIRService/Controllers/PIRServiceController.swift
+++ b/Sources/PIRService/Controllers/PIRServiceController.swift
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ApplicationProtobuf
 import Foundation
 import HomomorphicEncryptionProtobuf
 import Hummingbird
 import HummingbirdCompression
-import PrivateInformationRetrievalProtobuf
 import Util
 
 struct PIRServiceController {
@@ -57,7 +57,7 @@ struct PIRServiceController {
     func config(_ request: Request, context: AppContext) async throws -> some ResponseGenerator {
         context.logger.info("Tier = \(context.userTier)")
         let configRequest = try await request.decodeProto(
-            as: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigRequest.self,
+            as: Apple_SwiftHomomorphicEncryption_Api_V1_ConfigRequest.self,
             context: context)
         let requestedUsecases = if configRequest.usecases.isEmpty {
             await usecases.getAll()
@@ -77,7 +77,7 @@ struct PIRServiceController {
         let existingConfigIds = configRequest.existingConfigIds.isEmpty ? Array(
             repeating: Data(),
             count: requestedUsecases.count) : configRequest.existingConfigIds
-        var configs = [String: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config]()
+        var configs = [String: Apple_SwiftHomomorphicEncryption_Api_V1_Config]()
         for (usecaseName, configId) in zip(requestedUsecases.keys, existingConfigIds) {
             if let usecase = requestedUsecases[usecaseName] {
                 var config = try usecase.config(existingConfigId: Array(configId))
@@ -104,7 +104,7 @@ struct PIRServiceController {
 
         let keyStatuses: [Apple_SwiftHomomorphicEncryption_Api_Shared_V1_KeyStatus] =
             try await .init(keyStatusesSequence)
-        return Protobuf(Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigResponse.with { configResponse in
+        return Protobuf(Apple_SwiftHomomorphicEncryption_Api_V1_ConfigResponse.with { configResponse in
             configResponse.configs = configs
             configResponse.keyInfo = keyStatuses
         })
@@ -114,7 +114,7 @@ struct PIRServiceController {
     func queries(_ request: Request, context: AppContext) async throws -> some ResponseGenerator {
         let startTime = Date.now
         let requests = try await request.decodeProto(
-            as: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Requests.self,
+            as: Apple_SwiftHomomorphicEncryption_Api_V1_Requests.self,
             context: context)
 
         defer {
@@ -158,12 +158,14 @@ struct PIRServiceController {
                     throw HTTPError(.badRequest, message: "Unknown usecase: \(request.usecase)")
                 }
                 return try await usecase.process(request: request, evaluationKey: evaluationKey)
+            case .some(.pnnsRequest):
+                throw HTTPError(.badRequest, message: "Unknown request type.")
             case .none:
                 throw HTTPError(.badRequest, message: "Unknown request type.")
             }
         }
-        let responses: [Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response] = try await .init(responsesSequence)
-        return Protobuf(Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Responses.with { apiResponses in
+        let responses: [Apple_SwiftHomomorphicEncryption_Api_V1_Response] = try await .init(responsesSequence)
+        return Protobuf(Apple_SwiftHomomorphicEncryption_Api_V1_Responses.with { apiResponses in
             apiResponses.responses = responses
         })
     }

--- a/Sources/PIRService/Controllers/PirUsecase.swift
+++ b/Sources/PIRService/Controllers/PirUsecase.swift
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ApplicationProtobuf
 import Foundation
 import HomomorphicEncryption
 import HomomorphicEncryptionProtobuf
 import Hummingbird
 import PrivateInformationRetrieval
-import PrivateInformationRetrievalProtobuf
 import Util
 
 enum LoadingError: Error {
@@ -100,9 +100,9 @@ struct PirUsecase<PirScheme: IndexPirServer>: Usecase {
     @_specialize(where PirScheme == MulPirServer<Bfv<UInt32>>)
     @_specialize(where PirScheme == MulPirServer<Bfv<UInt64>>)
     func process(
-        request: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Request,
+        request: Apple_SwiftHomomorphicEncryption_Api_V1_Request,
         evaluationKey: Apple_SwiftHomomorphicEncryption_Api_Shared_V1_EvaluationKey) async throws
-        -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response
+        -> Apple_SwiftHomomorphicEncryption_Api_V1_Response
     {
         let pirRequest = request.pirRequest
         guard !pirRequest.hasShardID else {
@@ -112,12 +112,12 @@ struct PirUsecase<PirScheme: IndexPirServer>: Usecase {
         let query: KeywordPirServer<PirScheme>.Query = try pirRequest.query.native(context: context)
         let evaluationKey: EvaluationKey<Scheme> = try evaluationKey.evaluationKey.native(context: context)
         let response = try shard.computeResponse(to: query, using: evaluationKey)
-        return try Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response.with { apiResponse in
+        return try Apple_SwiftHomomorphicEncryption_Api_V1_Response.with { apiResponse in
             apiResponse.pirResponse = try response.proto()
         }
     }
 
-    func config() throws -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config {
+    func config() throws -> Apple_SwiftHomomorphicEncryption_Api_V1_Config {
         var pirConfig = Apple_SwiftHomomorphicEncryption_Api_Pir_V1_PIRConfig()
         pirConfig.encryptionParameters = try context.encryptionParameters.proto()
         guard let firstShard = shards.first else {
@@ -146,7 +146,7 @@ struct PirUsecase<PirScheme: IndexPirServer>: Usecase {
             pirConfig.shardConfigs = []
         }
 
-        return try Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config.with { config in
+        return try Apple_SwiftHomomorphicEncryption_Api_V1_Config.with { config in
             config.pirConfig = pirConfig
             config.configID = try pirConfig.sha256()
         }
@@ -159,14 +159,14 @@ struct PirUsecase<PirScheme: IndexPirServer>: Usecase {
     @_specialize(where PirScheme == MulPirServer<Bfv<UInt32>>)
     @_specialize(where PirScheme == MulPirServer<Bfv<UInt64>>)
     func processOprf(request: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_OPRFRequest) async throws ->
-        Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response
+        Apple_SwiftHomomorphicEncryption_Api_V1_Response
     {
         guard let symmetricPirConfig else {
             throw SymmetricPirError.symmetricPirNotConfigured
         }
         let oprfResponse = try OprfServer(symmetricPirConfig: symmetricPirConfig).computeResponse(
             query: request.native())
-        return Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response.with { apiResponse in
+        return Apple_SwiftHomomorphicEncryption_Api_V1_Response.with { apiResponse in
             apiResponse.oprfResponse = oprfResponse.proto()
         }
     }

--- a/Sources/PIRService/Controllers/Usecase.swift
+++ b/Sources/PIRService/Controllers/Usecase.swift
@@ -12,31 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ApplicationProtobuf
 import HomomorphicEncryptionProtobuf
-import PrivateInformationRetrievalProtobuf
 import Util
 
 protocol Usecase: Sendable {
     /// Returns the configuration.
     ///
     /// Note: may use features that are not compatible with older platforms.
-    /// ``PrivateInformationRetrievalProtobuf/Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config/makeCompatible(with:)``
+    /// ``ApplicationProtobuf/Apple_SwiftHomomorphicEncryption_Api_V1_Config/makeCompatible(with:)``
     /// can be used to make the configuration compatible with older platforms.
-    func config() throws -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config
+    func config() throws -> Apple_SwiftHomomorphicEncryption_Api_V1_Config
     func evaluationKeyConfig() throws -> Apple_SwiftHomomorphicEncryption_V1_EvaluationKeyConfig
     func process(
-        request: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Request,
+        request: Apple_SwiftHomomorphicEncryption_Api_V1_Request,
         evaluationKey: Apple_SwiftHomomorphicEncryption_Api_Shared_V1_EvaluationKey) async throws
-        -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response
+        -> Apple_SwiftHomomorphicEncryption_Api_V1_Response
     func processOprf(request: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_OPRFRequest) async throws
-        -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response
+        -> Apple_SwiftHomomorphicEncryption_Api_V1_Response
 }
 
 extension Usecase {
-    func config(existingConfigId: [UInt8]) throws -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config {
+    func config(existingConfigId: [UInt8]) throws -> Apple_SwiftHomomorphicEncryption_Api_V1_Config {
         let config = try config()
         if Array(config.configID) == existingConfigId {
-            return Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config.with { apiConfig in
+            return Apple_SwiftHomomorphicEncryption_Api_V1_Config.with { apiConfig in
                 apiConfig.reuseExistingConfig = true
             }
         }

--- a/Sources/PIRService/Extensions/PirConfig+compatible.swift
+++ b/Sources/PIRService/Extensions/PirConfig+compatible.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ApplicationProtobuf
 import Hummingbird
-import PrivateInformationRetrievalProtobuf
 import Util
 
 extension Platform {
@@ -40,7 +40,7 @@ extension Platform {
     }
 }
 
-public extension Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config {
+public extension Apple_SwiftHomomorphicEncryption_Api_V1_Config {
     /// Makes the configuration compatible with the given platform.
     /// - Parameter platform: Device platform.
     mutating func makeCompatible(with platform: Platform) throws {

--- a/Sources/PIRServiceTesting/PIRClient+KeyRotation.swift
+++ b/Sources/PIRServiceTesting/PIRClient+KeyRotation.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ApplicationProtobuf
 import Foundation
 import HomomorphicEncryption
 import PrivateInformationRetrieval
-import PrivateInformationRetrievalProtobuf
 import SwiftProtobuf
 
 extension PIRClient {
     mutating func fetchKeyStatus(for usecase: String) async throws
         -> Apple_SwiftHomomorphicEncryption_Api_Shared_V1_KeyStatus
     {
-        let configRequest = Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigRequest.with { configRequest in
+        let configRequest = Apple_SwiftHomomorphicEncryption_Api_V1_ConfigRequest.with { configRequest in
             configRequest.usecases = [usecase]
             configRequest.existingConfigIds = [configCache[usecase]?.configurationId ?? Data()]
         }
 
-        let configResponse: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigResponse = try await post(
+        let configResponse: Apple_SwiftHomomorphicEncryption_Api_V1_ConfigResponse = try await post(
             path: "/config",
             body: configRequest)
         guard let config = configResponse.configs[usecase] else {

--- a/Sources/PIRServiceTesting/PIRClient.swift
+++ b/Sources/PIRServiceTesting/PIRClient.swift
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ApplicationProtobuf
 import Foundation
 import HomomorphicEncryption
 import HTTPTypes
 import HummingbirdTesting
 import PrivacyPass
 import PrivateInformationRetrieval
-import PrivateInformationRetrievalProtobuf
 import SwiftProtobuf
 import Util
 
@@ -152,16 +152,16 @@ public struct PIRClient<PIRClient: IndexPirClient> {
             }
         }
 
-        let requests = Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Requests.with { requests in
+        let requests = Apple_SwiftHomomorphicEncryption_Api_V1_Requests.with { requests in
             requests.requests = pirRequests.map { pirRequest in
-                Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Request.with { request in
+                Apple_SwiftHomomorphicEncryption_Api_V1_Request.with { request in
                     request.usecase = usecase
                     request.pirRequest = pirRequest
                 }
             }
         }
 
-        let responses: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Responses = try await post(
+        let responses: Apple_SwiftHomomorphicEncryption_Api_V1_Responses = try await post(
             path: "/queries",
             body: requests)
 
@@ -203,15 +203,15 @@ public struct PIRClient<PIRClient: IndexPirClient> {
         let oprfQueryContexts: [OprfQueryContext] = try keywords.map { keyword in
             try oprfClient.queryContext(at: keyword)
         }
-        let requests = Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Requests.with { requests in
+        let requests = Apple_SwiftHomomorphicEncryption_Api_V1_Requests.with { requests in
             requests.requests = oprfQueryContexts.map { queryContext in
-                Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Request.with { request in
+                Apple_SwiftHomomorphicEncryption_Api_V1_Request.with { request in
                     request.usecase = usecase
                     request.oprfRequest = queryContext.query.proto()
                 }
             }
         }
-        let responses: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Responses = try await post(
+        let responses: Apple_SwiftHomomorphicEncryption_Api_V1_Responses = try await post(
             path: "/queries",
             body: requests)
         let parsedOprfResponses: [OprfClient.ParsedOprfOutput] = try zip(responses.responses, oprfQueryContexts)

--- a/Sources/PIRServiceTesting/PIRConfig+ShardConfig.swift
+++ b/Sources/PIRServiceTesting/PIRConfig+ShardConfig.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ApplicationProtobuf
 import PrivateInformationRetrieval
-import PrivateInformationRetrievalProtobuf
 import Util
 
 public extension Apple_SwiftHomomorphicEncryption_Api_Pir_V1_PIRConfig {

--- a/Tests/PIRServiceTests/PIRServiceControllerTests.swift
+++ b/Tests/PIRServiceTests/PIRServiceControllerTests.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ApplicationProtobuf
 import Foundation
 import HomomorphicEncryption
 import HomomorphicEncryptionProtobuf
@@ -19,7 +20,6 @@ import Hummingbird
 import HummingbirdTesting
 @testable import PIRService
 import PrivateInformationRetrieval
-import PrivateInformationRetrievalProtobuf
 import Testing
 import Util
 
@@ -85,14 +85,14 @@ struct PIRServiceControllerTests {
         let app = try await buildApplication(usecaseStore: usecaseStore)
         let user = UserIdentifier()
 
-        let configRequest = Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigRequest.with { configReq in
+        let configRequest = Apple_SwiftHomomorphicEncryption_Api_V1_ConfigRequest.with { configReq in
             configReq.usecases = ["test"]
         }
         try await app.test(.live) { client in
             try await client.execute(uri: "/config", userIdentifier: user, message: configRequest) { response in
                 #expect(response.status == .ok)
                 let configResponse = try response
-                    .message(as: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigResponse.self)
+                    .message(as: Apple_SwiftHomomorphicEncryption_Api_V1_ConfigResponse.self)
                 #expect(try configResponse.configs["test"] == exampleUsecase.config())
                 #expect(try configResponse.keyInfo[0].keyConfig == exampleUsecase.evaluationKeyConfig())
             }
@@ -111,7 +111,7 @@ struct PIRServiceControllerTests {
             for platform: Platform in [.macOS15, .macOS15_2, .iOS18, .iOS18_2] {
                 // No or wrong existing configId
                 for existingConfigId in [Data(), Data([UInt8(1), 2])] {
-                    let configRequest = Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigRequest.with { configReq in
+                    let configRequest = Apple_SwiftHomomorphicEncryption_Api_V1_ConfigRequest.with { configReq in
                         configReq.usecases = ["test"]
                         configReq.existingConfigIds = [existingConfigId]
                     }
@@ -125,13 +125,13 @@ struct PIRServiceControllerTests {
                         var expectedConfig = try exampleUsecase.config()
                         try expectedConfig.makeCompatible(with: platform)
                         let configResponse = try response
-                            .message(as: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigResponse.self)
+                            .message(as: Apple_SwiftHomomorphicEncryption_Api_V1_ConfigResponse.self)
                         #expect(configResponse.configs["test"] == expectedConfig)
                         #expect(try configResponse.keyInfo[0].keyConfig == exampleUsecase.evaluationKeyConfig())
                     }
                 }
                 // Existing configId
-                let configRequestWithConfigId = try Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigRequest
+                let configRequestWithConfigId = try Apple_SwiftHomomorphicEncryption_Api_V1_ConfigRequest
                     .with { configReq in
                         configReq.usecases = ["test"]
                         configReq.existingConfigIds = try [exampleUsecase.config().configID]
@@ -144,7 +144,7 @@ struct PIRServiceControllerTests {
                 { response in
                     #expect(response.status == .ok)
                     let configResponse = try response
-                        .message(as: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigResponse.self)
+                        .message(as: Apple_SwiftHomomorphicEncryption_Api_V1_ConfigResponse.self)
                     #expect(configResponse.configs["test"]?.reuseExistingConfig == true)
                     #expect(configResponse.configs["test"]?.pirConfig ==
                         Apple_SwiftHomomorphicEncryption_Api_Pir_V1_PIRConfig())
@@ -158,7 +158,7 @@ struct PIRServiceControllerTests {
     func compressedConfigFetch() async throws {
         // Mock usecase that has a large config with 10K randomized shardConfigs.
         struct TestUseCaseWithLargeConfig: Usecase {
-            let randomConfig: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config
+            let randomConfig: Apple_SwiftHomomorphicEncryption_Api_V1_Config
 
             init() throws {
                 let shardConfigs = (0..<10000).map { _ in
@@ -172,13 +172,13 @@ struct PIRServiceControllerTests {
                 let pirConfg = Apple_SwiftHomomorphicEncryption_Api_Pir_V1_PIRConfig.with { pirConfig in
                     pirConfig.shardConfigs = shardConfigs
                 }
-                self.randomConfig = try Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config.with { config in
+                self.randomConfig = try Apple_SwiftHomomorphicEncryption_Api_V1_Config.with { config in
                     config.pirConfig = pirConfg
                     config.configID = try pirConfg.sha256()
                 }
             }
 
-            func config() throws -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config {
+            func config() throws -> Apple_SwiftHomomorphicEncryption_Api_V1_Config {
                 randomConfig
             }
 
@@ -187,17 +187,17 @@ struct PIRServiceControllerTests {
             }
 
             func process(
-                request _: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Request,
+                request _: Apple_SwiftHomomorphicEncryption_Api_V1_Request,
                 evaluationKey _: Apple_SwiftHomomorphicEncryption_Api_Shared_V1_EvaluationKey) async throws
-                -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response
+                -> Apple_SwiftHomomorphicEncryption_Api_V1_Response
             {
-                Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response()
+                Apple_SwiftHomomorphicEncryption_Api_V1_Response()
             }
 
             func processOprf(request _: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_OPRFRequest) async throws
-                -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response
+                -> Apple_SwiftHomomorphicEncryption_Api_V1_Response
             {
-                Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response()
+                Apple_SwiftHomomorphicEncryption_Api_V1_Response()
             }
         }
 
@@ -208,7 +208,7 @@ struct PIRServiceControllerTests {
         let app = try await buildApplication(usecaseStore: usecaseStore)
         let user = UserIdentifier()
 
-        let configRequest = Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigRequest.with { configReq in
+        let configRequest = Apple_SwiftHomomorphicEncryption_Api_V1_ConfigRequest.with { configReq in
             configReq.usecases = ["test"]
         }
 
@@ -226,7 +226,7 @@ struct PIRServiceControllerTests {
                 var compressedBody = response.body
                 #expect(compressedBody.readableBytes < uncompressedConfigSize)
                 let uncompressed = try compressedBody.decompress(with: .gzip())
-                let configResponse = try Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigResponse(
+                let configResponse = try Apple_SwiftHomomorphicEncryption_Api_V1_ConfigResponse(
                     serializedBytes: Array(buffer: uncompressed))
                 #expect(try configResponse.configs["test"] == exampleUsecase.config())
             }


### PR DESCRIPTION
Showing use of https://github.com/apple/swift-homomorphic-encryption/pull/232.
I figure we can keep this PR open as a reference, until swift-he releases `1.1.0`, at which point we can merge this PR.