### PR TITLE
Adopt error API to convey server errors to the client

### DIFF
--- a/Sources/PIRService/Controllers/PIRServiceController.swift
+++ b/Sources/PIRService/Controllers/PIRServiceController.swift
@@ -86,6 +86,20 @@ struct PIRServiceController {
         let existingConfigIds = configRequest.existingConfigIds.isEmpty ? Array(
             repeating: Data(),
             count: requestedUsecases.count) : configRequest.existingConfigIds
+        return try await Protobuf(configResponse(
+            usecases: requestedUsecases,
+            existingConfigIds: existingConfigIds,
+            context: context))
+    }
+
+    /// Builds a `ConfigResponse` for the given usecases, keyed by usecase name.
+    ///
+    /// `existingConfigIds` must have the same count as `usecases.count`, in the same iteration order.
+    private func configResponse(
+        usecases requestedUsecases: [String: Usecase],
+        existingConfigIds: [Data],
+        context: AppContext) async throws -> Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigResponse
+    {
         var configs = [String: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Config]()
         for (usecaseName, configId) in zip(requestedUsecases.keys, existingConfigIds) {
             if let usecase = requestedUsecases[usecaseName] {
@@ -113,10 +127,10 @@ struct PIRServiceController {
 
         let keyStatuses: [Apple_SwiftHomomorphicEncryption_Api_Shared_V1_KeyStatus] =
             try await .init(keyStatusesSequence)
-        return Protobuf(Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigResponse.with { configResponse in
+        return Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigResponse.with { configResponse in
             configResponse.configs = configs
             configResponse.keyInfo = keyStatuses
-        })
+        }
     }
 
     @Sendable
@@ -135,7 +149,7 @@ struct PIRServiceController {
             switch request.request {
             case let .oprfRequest(oprfRequest):
                 guard let usecase = await usecases.get(name: request.usecase) else {
-                    throw HTTPError(.badRequest, message: "Unknown usecase: \(request.usecase)")
+                    throw PIRServiceError.invalidRequest(message: "Unknown usecase: \(request.usecase)")
                 }
                 return try await usecase.processOprf(request: oprfRequest)
             case .pirRequest:
@@ -152,23 +166,25 @@ struct PIRServiceController {
                         as: Protobuf<Apple_SwiftHomomorphicEncryption_Api_Shared_V1_EvaluationKey>.self)?.message
                 }
                 guard let evaluationKey else {
-                    throw HTTPError(.badRequest, message: "Evaluation key not found")
+                    throw PIRServiceError.evaluationKeyNotFound
                 }
                 let configId = Array(request.pirRequest.configurationHash)
                 guard let usecase = await usecases.get(
                     name: request.usecase,
                     configId: configId)
                 else {
-                    if await (usecases.get(name: request.usecase)) != nil {
-                        throw HTTPError(
-                            .gone,
-                            message: "Configuration id: \(configId) is not available for usecase \(request.usecase).")
+                    guard let latestUsecase = await usecases.get(name: request.usecase) else {
+                        throw PIRServiceError.invalidRequest(message: "Unknown usecase: \(request.usecase)")
                     }
-                    throw HTTPError(.badRequest, message: "Unknown usecase: \(request.usecase)")
+                    let staleConfigResponse = try await configResponse(
+                        usecases: [request.usecase: latestUsecase],
+                        existingConfigIds: [Data()],
+                        context: context)
+                    throw PIRServiceError.configVersionNotFound(configResponse: staleConfigResponse)
                 }
                 return try await usecase.process(request: request, evaluationKey: evaluationKey)
             case .none:
-                throw HTTPError(.badRequest, message: "Unknown request type.")
+                throw PIRServiceError.invalidRequest(message: "Unknown request type.")
             }
         }
         let responses: [Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Response] = try await .init(responsesSequence)

--- a/Sources/PIRService/Extensions/PIRServiceError+HTTPErrorResponse.swift
+++ b/Sources/PIRService/Extensions/PIRServiceError+HTTPErrorResponse.swift
@@ -1,0 +1,67 @@
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Hummingbird
+import PrivateInformationRetrievalProtobuf
+
+/// Errors reported to the client using the `Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Error` protobuf message.
+enum PIRServiceError: Error {
+    /// Client's configuration is stale or unknown. `configResponse`, if present, is the configuration the client
+    /// should use for subsequent requests.
+    case configVersionNotFound(configResponse: Apple_SwiftHomomorphicEncryption_Api_Pir_V1_ConfigResponse?)
+    /// Client's evaluation key was not found on the server.
+    case evaluationKeyNotFound
+    /// Request could not be processed. `message` is for server-side logging only; it is not sent to the client.
+    case invalidRequest(message: String)
+}
+
+extension PIRServiceError: Hummingbird.HTTPResponseError {
+    public var status: HTTPResponse.Status {
+        switch self {
+        case .configVersionNotFound: .gone
+        case .evaluationKeyNotFound: .badRequest
+        case .invalidRequest: .badRequest
+        }
+    }
+
+    public func response(from _: Request, context _: some RequestContext) throws -> Response {
+        let error = Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Error.with { error in
+            switch self {
+            case let .configVersionNotFound(configResponse):
+                error.configVersionNotFound = .with { configVersionNotFound in
+                    if let configResponse {
+                        configVersionNotFound.configResponse = configResponse
+                    }
+                }
+            case .evaluationKeyNotFound:
+                error.evaluationKeyNotFound = .init()
+            case .invalidRequest:
+                error.invalidRequest = .init()
+            }
+        }
+        let serialized = try error.serializedData()
+        return Response(status: status, body: ResponseBody(byteBuffer: ByteBuffer(bytes: serialized)))
+    }
+}
+
+extension PIRServiceError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .configVersionNotFound: "Configuration id is not available"
+        case .evaluationKeyNotFound: "Evaluation key not found"
+        case let .invalidRequest(message): message
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `PIRServiceError` type that serializes the new `Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Error` protobuf message (from apple/swift-homomorphic-encryption-protobuf#21) as the HTTP response body, following the same `HTTPResponseError` pattern already used for `HeError`/`PirError`.
- Rewires the four error paths in `PIRServiceController.queries()` to throw `PIRServiceError` instead of plain `HTTPError`:
  - Unknown usecase / unparseable request -> `invalidRequest`
  - Missing evaluation key -> `evaluationKeyNotFound`
  - Stale/unknown config id -> `configVersionNotFound`, now with a **fresh `ConfigResponse` embedded in the error body**, so the client can retry immediately without a second config round trip (this is what #94's linked comment asked for).
- Factored the config-building logic in `config()` into a shared `configResponse(usecases:existingConfigIds:context:)` helper reused by both endpoints.

Fixes #102.

## Test plan
- [ ] CI (build + swift test)
- [ ] Manual smoke test: send a `queries` request with a stale `configurationHash` and confirm the response body decodes as `Apple_SwiftHomomorphicEncryption_Api_Pir_V1_Error` with `configVersionNotFound.configResponse` populated